### PR TITLE
antenna

### DIFF
--- a/scripts/device/ROS_antenna_move.py
+++ b/scripts/device/ROS_antenna_move.py
@@ -297,16 +297,19 @@ class antenna_move(object):
     def stop_move(self, req):
         if time.time() - self.start_time < 1:
             return
-        
+
         if req.data == False:
+            self.stop_flag = False
             pass
         else:
             rospy.loginfo('***subscribe move stop***')
-            self.parameters['az_list'] = []
-            self.parameters['el_list'] = []
-            self.parameters["start_time_list"] = []
-        
-        self.stop_flag = req.data
+            for i in range(3):
+                self.parameters['az_list'] = []
+                self.parameters['el_list'] = []
+                self.parameters["start_time_list"] = []
+                self.stop_flag = True
+                time.sleep(1.)
+            self.stop_flag = True                
         return  
 
     def emergency(self,req):


### PR DESCRIPTION
遅延が大きいと azel_list のstop_flag = False を受け取ってしまうため、
antenna_move の停止を確実にできるように修正