### PR TITLE
Dome finalize bugfix

### DIFF
--- a/lib/device/dome_device.py
+++ b/lib/device/dome_device.py
@@ -39,9 +39,7 @@ class dome_device(object):
     def move(self, dist, pos, track=False):
         pos_arcsec = float(pos)#[arcsec]
         pos = pos_arcsec/3600.
-        print("pos: ", pos)
         pos = pos % 360.0
-        print("dist: ", dist)
         dist = float(dist) % 360.0
         diff = dist - pos
         dir = diff % 360.0
@@ -64,7 +62,6 @@ class dome_device(object):
                 turn = 'left'
             else:
                 turn = 'right'
-        print(abs(dir))
         if abs(dir) < 5.0 or abs(dir) > 355.0:
             speed = 'low'
         elif abs(dir) > 15.0 and abs(dir) < 345.0:

--- a/scripts/device/ROS_dome.py
+++ b/scripts/device/ROS_dome.py
@@ -205,7 +205,6 @@ class dome_controller(object):
 
     def set_az_command(self, req):
         self.parameter_az = req.value
-        print("set:  ", self.parameter_az)
         return
 
     ###function call to dome/memb action 
@@ -336,6 +335,6 @@ if __name__ == '__main__':
     print('[ROS_dome.py] : START SUBSCRIBE')
     sub1 = rospy.Subscriber('status_encoder', Status_encoder_msg, d.set_enc_parameter)
     sub2 = rospy.Subscriber('dome_move', Dome_msg, d.set_command)
-    sub3 = rospy.Subscriber('dome_move_az', Dome_msg, self.set_az_command)
+    sub3 = rospy.Subscriber('dome_move_az', Dome_msg, d.set_az_command)
     rospy.spin()
     

--- a/scripts/device/ROS_dome.py
+++ b/scripts/device/ROS_dome.py
@@ -33,7 +33,7 @@ class dome_controller(object):
         'command':0
         }
     paralist = []
-    parameter_az = 5
+    parameter_az = 0
     ###command flags
     end_flag = True
 
@@ -109,7 +109,6 @@ class dome_controller(object):
     def con_move(self, dist):
         while not self.end_flag:
             pos = self.dome_enc
-            print("con_move_dist: ",dist)
             dir = self.dev.move(dist, pos)
             print(dir,'<1.5 => stop')
             if dir <= 1.5 or dir >= 358.5:
@@ -205,7 +204,6 @@ class dome_controller(object):
         return
 
     def set_az_command(self, req):
-        print("req:  ", req.value)
         self.parameter_az = req.value
         print("set:  ", self.parameter_az)
         return
@@ -266,7 +264,6 @@ class dome_controller(object):
                 continue
             elif "dome_move" in self.paralist and "dome_tracking" in self.paralist:
                 if self.paralist.index("dome_move") < self.paralist.index("dome_tracking"):
-                    sub3 = rospy.Subscriber('dome_move_az', Dome_msg, self.set_az_command)
                     time.sleep(0.1)
                     self.end_flag = False
                     self.con_move(self.parameter_az)
@@ -274,10 +271,8 @@ class dome_controller(object):
                     self.end_flag = False
                     self.con_move_track()
             elif "dome_move" in self.paralist:
-                sub3 = rospy.Subscriber('dome_move_az', Dome_msg, self.set_az_command)
                 time.sleep(0.1)
                 self.end_flag = False
-                print("target_az  ", self.parameter_az)
                 self.con_move(self.parameter_az)
             elif "dome_tracking" in self.paralist:
                 self.end_flag = False
@@ -341,5 +336,6 @@ if __name__ == '__main__':
     print('[ROS_dome.py] : START SUBSCRIBE')
     sub1 = rospy.Subscriber('status_encoder', Status_encoder_msg, d.set_enc_parameter)
     sub2 = rospy.Subscriber('dome_move', Dome_msg, d.set_command)
+    sub3 = rospy.Subscriber('dome_move_az', Dome_msg, self.set_az_command)
     rospy.spin()
     


### PR DESCRIPTION
finalize.py において dome_move(90) が指示されない問題を解決しました。

問題点は subscriber の登録が間に合っていないことでした。

ROS_dome.py 内のdome_move_az の subscriber を立ち上げる位置をmain関数部に移動しました。
要らないprint 文を削除しました。