### PR TITLE
Tracking

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,6 +90,7 @@ add_message_files(
 add_service_files(
   FILES
   ac240_srv.srv
+  Bool_srv.srv  
 #  String_srv.srv
 )
 

--- a/scripts/device/ROS_antenna_move.py
+++ b/scripts/device/ROS_antenna_move.py
@@ -17,6 +17,7 @@ from necst.msg import List_coord_msg
 from necst.msg import Status_encoder_msg
 from necst.msg import Bool_necst
 from necst.msg import Status_pid_msg
+from necst.srv import Bool_srv
 
 node_name = 'antenna_move'
 mode = sys.argv[1]#'Actual/Simulator'
@@ -332,28 +333,27 @@ class antenna_move(object):
     def stop_move(self, req):
         if time.time() - self.start_time < 1:
             return
-
+        
+        rospy.logerr(time.time())    
         print(req.data)##
         rospy.loginfo('***subscribe move stop***')
         self.stop_flag = True        
-        for i in range(3):
-            self.parameters['az_list'] = []
-            self.parameters['el_list'] = []
-            self.parameters["start_time_list"] = []
-            time.sleep(1.)
+        self.parameters['az_list'] = []
+        self.parameters['el_list'] = []
+        self.parameters["start_time_list"] = []
         return
         
 
     def move_check(self,req):
         if time.time() - self.start_time < 1:
-            return
+            return False
 
         if req.data == True:
             self.move_flag = True
             self.stop_flag = False
         else:
             self.move_flag = False
-        return
+        return True
         
         
 
@@ -430,8 +430,9 @@ if __name__ == '__main__':
     print('[ROS_antenna_move.py] : START SUBSCRIBE')
     rospy.Subscriber('list_azel', List_coord_msg, ant.set_parameter, queue_size=1000)
     rospy.Subscriber('move_stop', Bool_necst, ant.stop_move)
-    rospy.Subscriber('move_flag', Bool_necst, ant.move_check)    
+    #rospy.Subscriber('move_flag', Bool_necst, ant.move_check)    
     rospy.Subscriber('emergency_stop', Bool_necst, ant.emergency)
     rospy.Subscriber('status_encoder', Status_encoder_msg, ant.set_enc_parameter, queue_size=1)
     rospy.Subscriber('tracking_check', Bool_necst, ant.set_tracking, queue_size=1)
+    rospy.Service("move_flag",Bool_srv, ant.move_check)
     rospy.spin()    

--- a/scripts/device/ROS_azel_list.py
+++ b/scripts/device/ROS_azel_list.py
@@ -213,7 +213,6 @@ class azel_list(object):
                     #self.msg.timestamp = time.time()
                     #self.msg.data = self.move_flag                    
                     #self.move.publish(self.msg)
-                    print("##################")
                     rospy.wait_for_service("move_flag")
                     print("wait comunication to antenna_move...")
                     response = self.service(True)

--- a/scripts/device/ROS_oneshot_achilles.py
+++ b/scripts/device/ROS_oneshot_achilles.py
@@ -17,20 +17,14 @@ def oneshot(req):
     dfs = achilles.dfs()
     data = dfs.oneshot(req.repeat, req.exposure, req.stime)
     
-    #data = [
-    #    [[[10000.0+np.random.randint(1000) for i in range(16384)]]*int(req.repeat),10],
-    #    [[[20000.0+np.random.randint(1000) for i in range(16384)]]*int(req.repeat),20]
-    #]
-    
     data0 = []
     data1 = []
     print(list(data[0][0]))
     print(len(list(data[0][0])))
     calc0 = [data0.extend(i) for i in list(data[0])]
     calc1 = [data1.extend(i) for i in list(data[1])]            
-    time.sleep(req.exposure*req.repeat)
+
     print("fin")
-    #return ac240_srvResponse(data0, data[0][1].tolist(), data1, data[1][1].tolist())
     return ac240_srvResponse(data0, data1)    
 
 if __name__ == "__main__":

--- a/scripts/device/ROS_scan_planet.py
+++ b/scripts/device/ROS_scan_planet.py
@@ -89,7 +89,7 @@ class worldcoord(object):
             msg.limit = command.limit
             msg.timestamp = current_time
             self.pub.publish(msg)
-            #print(msg)
+            print(msg.time_list)
             print("publish status!!\n")
             print("end_create_list\n")
         return

--- a/scripts/helper/ROS_alert_sun.py
+++ b/scripts/helper/ROS_alert_sun.py
@@ -21,7 +21,8 @@ class alert(object):
     alert_msg = ""
     emergency = ""
     warning = ""
-    dome_flag = True
+    status_dome = "OPEN"
+    status_memb = "OPEN"    
 
     def __init__(self):
         self.sub = rospy.Subscriber("list_azel", List_coord_msg, self.callback_azel)
@@ -99,19 +100,22 @@ class alert(object):
 
             check_az = [i for i in az_list if 0<abs(i-sun_az)<15*3600. or 345*3600.<abs(i-sun_az)<360*3600.]
             check_el = [i for i in el_list if 0<abs(i-sun_el)<15*3600.]
+
             #try:
             status = con.read_status()
-            if status.Door_Dome.upper() == "CLOSE":
-                self.dome_flag = False
-            else:
-                self.dome_flag = True                    
+            self.status_dome = status.Door_Dome.upper()
+            self.status_memb = status.Door_Membrane.upper()
             #except Exception as e:
                 #self.dome_flag = True
                 #rospy.logerr(e)
-            if check_az and check_el and self.dome_flag != False:
+            if check_az and check_el and self.status_dome != "CLOSE" and self.status_memb != "CLOSE":
                 emergency += "Emergency : antenna position near sun!! \n"
             elif check_az and check_el:
                 warning += "Warning : antenna position near sun!! \n"
+                warning += "dome status : "
+                warning += self.status_dome+"\n"
+                warning += "memb status : "
+                warning += self.status_memb+"\n"             
             else:
                 pass
             

--- a/scripts/helper/ROS_tracking.py
+++ b/scripts/helper/ROS_tracking.py
@@ -19,7 +19,21 @@ class tracking_check(object):
         'command_az' : 200,
         'command_el' : 200
         }
+    """
+    coordinate_param = {
+        "x_list" : "",
+        "y_list" : "",
+        "off_x" : "",
+        "off_y" : "",
+        "coord" : ""
+        }
+    """
+    coordinate_param = ""
     tracking = False
+    coord_flag = False
+    command_flag = False
+    same_coord_flag = False
+    receive_flag1 = False
     
     list_coord = ''
     before_x = -10
@@ -40,36 +54,81 @@ class tracking_check(object):
         
 
     def set_ant_param(self, req):
-        #rospy.loginfo(req.command_az)
-        #rospy.loginfo(req.command_el)
+        if abs(self.antenna_param['command_az']-req.command_az) > 3 or abs(self.antenna_param['command_az']-req.command_az) > 3:
+            self.command_flag = True
+            #rospy.logwarn("change command")
+        else:
+            pass        
         self.antenna_param['command_az'] = req.command_az
         self.antenna_param['command_el'] = req.command_el
+        return
 
     def set_enc_param(self, req):
-        #rospy.loginfo(req.enc_az)
-        #rospy.loginfo(req.enc_el)
         self.enc_param['enc_az'] = req.enc_az
         self.enc_param['enc_el'] = req.enc_el
+        return
 
     def set_list_param(self, req):
-        self.list_coord = req.coord
-        if self.list_coord == 'altaz':
-            if  not abs(self.before_x - req.x_list[0]) < 0.0001 or not abs(self.before_y - req.y_list[0]) < 0.0001:
-                self.before_x = req.x_list[0]
-                self.before_y = req.y_list[0]
-                self.same_azel_list_flag = False
+        # check new list
+        tmp_list = self.coordinate_param        
+        try:
+            tmp_list.x_list = [round(i,1) for i in tmp_list.x_list]
+            tmp_list.y_list = [round(i,1) for i in tmp_list.y_list]           
+            tmp_list.time_list = []
+            tmp_list.timestamp = 0.0
+        except:
+            print("First receive !!")
+        tmp_req = req
+        tmp_req.x_list = [round(i,1) for i in tmp_req.x_list]
+        tmp_req.y_list = [round(i,1) for i in tmp_req.y_list]           
+        tmp_req.timestamp = 0.0
+        tmp_req.time_list = []
+
+        # parameter change
+        if tmp_list == tmp_req:
+            rospy.logerr("same command !!")
+            if tmp_req.coord == "altaz":
+                self.same_coord_flag = True
             else:
-                self.same_azel_list_flag = True
-            
-        
+                self.same_coord_flag = False
+        else:
+            self.same_coord_flag = False
+        self.coordinate_param = req
+        self.coord_flag = True
+        self.receive_flag1 = True        
+        return
+
     def check_track(self):
         track_count = 0
-        pub = rospy.Publisher("move_stop", Bool_necst, queue_size = 1)
+        pub = rospy.Publisher("move_flag", Bool_necst, queue_size = 1)
+        while not self.coordinate_param:
+            print("wait command...")
+            time.sleep(0.1)
         while not rospy.is_shutdown():
+            #current_coordinate = self.coordinate_param
             command_az = self.antenna_param['command_az']
             command_el = self.antenna_param['command_el']
+            command_coord = self.coordinate_param.coord   
+            #print(current_coordinate,command_az, command_el)
+
+            if not self.coord_flag:
+                print("coordinate check")
+                time.sleep(0.1)
+                continue
+            else:
+                print("coordinate clear")
+                self.tarcking = False                
+                pass
+
+            if self.command_flag == False or self.same_coord_flag == True:
+                print("same command")
+                time.sleep(0.1)
+                continue                
+
+            """ start checking track """
             enc_az = self.enc_param['enc_az']
-            enc_el = self.enc_param['enc_el']
+            enc_el = self.enc_param['enc_el']            
+            
             if command_az < 0:
                 command_az += 360*3600
             if enc_az <0:
@@ -79,23 +138,20 @@ class tracking_check(object):
 
             list_coord = self.list_coord
                 
-            #rospy.loginfo( self.antenna_param['command_az'])
             if d_az <= 3 and d_el <=3:
                 track_count += 1
             else:
                 track_count = 0
-            if track_count >= 3:
+            if track_count >= 5:# if tracking is True for 0.5[se]
                 self.tracking = True
-                track_count = 3
+                if command_coord == "altaz":
+                    pub.publish(False, 'ROS_tracking.py', time.time())
+
+                self.coord_flag = False
+                self.command_flag = False
+                track_count = 0
             else:
                 self.tracking = False
-                pub_flag = 0
-
-            if self.tracking == True and list_coord == 'altaz' and self.same_azel_list_flag and pub_flag == 0:
-                pub.publish(True, 'ROS_tracking.py', time.time())
-                pub_flag =1
-            else:
-                pass
             
             time.sleep(0.1)
             rospy.loginfo('tracking : %s'%self.tracking)
@@ -105,11 +161,7 @@ class tracking_check(object):
         pub = rospy.Publisher('tracking_check', Bool_necst, queue_size = 10, latch = True)
         track_status = Bool_necst()
         while not rospy.is_shutdown():
-            if self.tracking:
-                track_status.data = True
-            else:
-                track_status.data = False
-                pass
+            track_status.data = self.tracking
             track_status.from_node = node_name
             track_status.timestamp = time.time()
             pub.publish(track_status)
@@ -120,5 +172,5 @@ if __name__ == '__main__':
     t = tracking_check()
     sub1 = rospy.Subscriber('status_antenna', Status_antenna_msg, t.set_ant_param)
     sub2 = rospy.Subscriber('status_encoder',Status_encoder_msg, t.set_enc_param)
-    sub3 = rospy.Subscriber('list_azel',List_coord_msg, t.set_list_param, queue_size = 1)
+    sub3 = rospy.Subscriber('wc_list',List_coord_msg, t.set_list_param, queue_size = 1)
     rospy.spin()

--- a/scripts/helper/ROS_tracking.py
+++ b/scripts/helper/ROS_tracking.py
@@ -58,7 +58,7 @@ class tracking_check(object):
             self.command_flag = True
             #rospy.logwarn("change command")
         else:
-            pass        
+            pass
         self.antenna_param['command_az'] = req.command_az
         self.antenna_param['command_el'] = req.command_el
         return
@@ -100,7 +100,7 @@ class tracking_check(object):
 
     def check_track(self):
         track_count = 0
-        pub = rospy.Publisher("move_flag", Bool_necst, queue_size = 1)
+        pub = rospy.Publisher("move_stop", Bool_necst, queue_size = 1)
         while not self.coordinate_param:
             print("wait command...")
             time.sleep(0.1)

--- a/srv/Bool_srv.srv
+++ b/srv/Bool_srv.srv
@@ -1,0 +1,4 @@
+bool data
+
+---
+bool data


### PR DESCRIPTION
・tracking を大幅に変更
　　仕組み自体はあまり変わってないはず...
　　次回速度でも判定できるようにします
・stop_flag と move_flag を分けました
　　stop した時に確実にリストを消して停止するために stop_flag の方に timesleep を入れてましたが、
　　バグのため削除 (timesleep で止めると queue_size=1 でも subscriber が蓄積するため)
　　ROS_azel_list.py からの move_flag の配信を最初の一回だけにしたため、
　　リストを消さなくても実行されずに駆動しません
　　move_flag を切り替えずに stop_flag を解除することはできないためリストが残っても問題ないです
・antenna_move を move_flag が来るのを待ってから動かすように service を使うようにしました(要相談)
　　型の追加をしたので catkin_make お願いします
・L205 time_check の中で、現存のリストが過去の時 stop_flag を立てていたため廃止
　　planet_move などは遅いため 2,3 回目に有効リストが送られてくるので
　　どのみち return NULL を返す時点で駆動はしないため不要と判断
・oneshot にsimulator 実装時の sleep が残ってたため削除(観測時間が長かった原因だと思われる)
・oneshot の simulator の修正
・太陽の alert の編集
　　太陽に近づいた時に一時的にアンテナをとめます
　　デフォルトの状態で memb open /dome close の駆動を可能にしました
　　ついでに dome close/ memb open もいけます

  