### PR TITLE
pyinterface

### DIFF
--- a/scripts/helper/ROS_limit_check.py
+++ b/scripts/helper/ROS_limit_check.py
@@ -34,7 +34,7 @@ limit_pub = rospy.Publisher("limit", Bool_necst, queue_size=10, latch=True)
 
 while not rospy.is_shutdown():#stop_flag == 0:
     msg = ""
-    ret = dio.input_dword().to_list()
+    ret = dio.input_dword("IN1_32").to_list()
     for i in range(4,16):
         if ret[i] == 0:
             msg = msg+str(limit_list[i+1])


### PR DESCRIPTION
dword を pyinterface の更新に伴い変更
それ以外は特に変更してないようですので現状のメモ

m2 : 2724
.to_list() 使えるみたいなので特に問題なし
drive : 2724
output_point が使えれば問題なし
dome : 2724
上に加え、input_point 使えれば
(.to_list() とかはない list でかえってくる)
abs : 2724
同上
m4 : 7204
get_position とか変わってない限り
