### PR TITLE
Antenna1221

### DIFF
--- a/scripts/device/ROS_antenna_move.py
+++ b/scripts/device/ROS_antenna_move.py
@@ -118,8 +118,11 @@ class antenna_move(object):
         if self.stop_flag and req.timestamp == self.timestamp :
             self.parameters = {"az_list":[], "el_list":[], "start_time_list":[]}
             return
+        elif req.timestamp == self.timestamp and self.parameters["az_list"]==[]:
+            return
         else:
             self.stop_flag = False
+            self.timestamp = req.timestamp
         
         """
         DESCRIPTION

--- a/scripts/device/ROS_azel_list.py
+++ b/scripts/device/ROS_azel_list.py
@@ -219,6 +219,7 @@ class azel_list(object):
                         pass
                     limit_flag = False
 
+                """
                 if self.move_count == 0:
                     #self.msg.timestamp = time.time()
                     #self.msg.data = self.move_flag                    
@@ -233,14 +234,14 @@ class azel_list(object):
                         print("connect antenna_move! ")                        
                         pass
                     self.move_count += 1
-                    
+                """    
                 if not limit_flag:
                     msg.x_list = ret[0]
                     msg.y_list = ret[1]
                     msg.coord = param.coord
                     msg.time_list = time_list2
                     msg.from_node =node_name
-                    msg.timestamp = time.time()
+                    msg.timestamp = param.timestamp
                     self.pub.publish(msg)
                     print("msg", msg)
                     print("publish ok")

--- a/scripts/device/ROS_azel_list.py
+++ b/scripts/device/ROS_azel_list.py
@@ -5,8 +5,6 @@ from necst.msg import List_coord_msg
 from necst.msg import Status_weather_msg
 from necst.msg import Bool_necst
 from necst.msg import String_necst
-from necst.srv import Bool_srv
-from necst.srv import Bool_srvResponse
 
 from datetime import datetime
 from astropy.time import Time
@@ -36,13 +34,10 @@ class azel_list(object):
         rospy.Subscriber("wc_list", List_coord_msg, self._receive_list, queue_size=1)
         rospy.Subscriber("status_weather", Status_weather_msg, self._receive_weather, queue_size=1)
         rospy.Subscriber("move_stop", Bool_necst, self._stop, queue_size=1)
-        rospy.Subscriber("move_flag", Bool_necst, self._move_check, queue_size=1)             
         
         self.pub = rospy.Publisher("list_azel", List_coord_msg, queue_size=1000)
         #self.stop = rospy.Publisher("move_stop", Bool_necst, queue_size=1)
-        #self.move = rospy.Publisher("move_flag", Bool_necst, queue_size=1)     
         self.obs_stop = rospy.Publisher("obs_stop", String_necst, queue_size=1)
-        self.service = rospy.ServiceProxy("move_flag", Bool_srv)
         
         self.msg = Bool_necst()
         self.msg.from_node = node_name

--- a/scripts/record/ROS_ac240_time.py
+++ b/scripts/record/ROS_ac240_time.py
@@ -8,9 +8,11 @@ from necst.msg import String_list_msg
 
 def _get_data(req):
     if float(req.data[2]) == 0:
-        return
-    stime = (float(req.data[2])-40587)*24*3600
-    etime = stime + float(req.data[0])*float(req.data[1])
+        etime = time.time()
+        stime = etime - float(req.data[0])*float(req.data[1])        
+    else:
+        stime = (float(req.data[2])-40587)*24*3600
+        etime = stime + float(req.data[0])*float(req.data[1])
     f.write(str(time.time())+" "+str(stime)+" "+str(etime)+"\n")
     print("save_file : ", save_dir+file_name)
     return


### PR DESCRIPTION
駆動指示が通らないことがあるバグの修正
move_flag の管理を廃止して、stop_flag が入ってる限り駆動しないシンプルな設計に変更
仮に、azel_list から追加の指示がきても timestamp が同じ限りは駆動しない
(azel_list の timestamp を wc_list の timestamp に固定)