### PR TITLE
new_script_pressmeter

### DIFF
--- a/scripts/device/ROS_press_meter.py
+++ b/scripts/device/ROS_press_meter.py
@@ -1,0 +1,31 @@
+import rospy
+from std_msgs.msg import Float64
+import sys
+sys.path.append('/home/pi/git/ads')
+import ads1256
+import time
+
+rospy.init_node('press_raspi')
+
+pub = rospy.Publisher('press_raspi', Float64, queue_size = 1)
+
+def read_press():
+    data = ads1256.ads1256_adc()
+    data_v = data['CH2']
+    """#for recording voltage from press meter
+    f = open('voltage20180110.txt', 'a')
+    str = '{} {}\n'.format(time.time(), data_v)
+    f.write(str)
+    f.close()
+    """
+    #press = (data_v*10/4096-5.)/3.8*1013.25#original
+    #press = (239.04*data_v-85.005)/0.75006157584566# conversion voltage into press[hPa]~2019/01
+    press = (196.84*data_v + 5.2934)/0.75006157584566# conversion voltage into press[hPa]2019/01/30~
+    print(press,"[hPa]", data_v)
+    return press
+
+while  1:
+    press = read_press()
+    pub.publish(press)
+    time.sleep(1)
+    


### PR DESCRIPTION
## 気圧計
### 概要
ラズパイで気圧計をA/Dして、気圧情報をpublishするスクリプト。Dコンテナのラズパイで使用

### 変換式について
気圧計の情報はnanmeteoでかつて取得していたが、ラズパイに置き換えた。そのさい変換式がわからなかったため、気圧計全面のディスプレイと電圧を同時に取得し新たに変換式を求めた。ただしディスプレイの気圧表示は有効数字が電圧より小さく、電圧と気圧が一意に定まらなかった。そのため線形近似して変換式を導出した。まだ大量のデータが残っているので今後も変換式をupdateする可能性あり。
<div align="center">
<img src=https://user-images.githubusercontent.com/31982651/51958095-be1de980-2491-11e9-9220-5b4c9aa84100.png width=400>
</div>

### module
ラズパイのA/Dのモジュールは下のものを使用
[リンク](https://github.com/keisukesakasai/ads1256)



